### PR TITLE
Non Animated Transition & Key Window

### DIFF
--- a/Sources/Overlayer/OverlayerModifier.swift
+++ b/Sources/Overlayer/OverlayerModifier.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct OverlayerOptionalModifier<Item: Equatable, ViewContent: View>: ViewModifier {
-  var animation: Animation
+  var animation: Animation?
   @Binding var item: Item?
   @ViewBuilder var viewContent: (Item) -> ViewContent
   
@@ -38,15 +38,25 @@ struct OverlayerOptionalModifier<Item: Equatable, ViewContent: View>: ViewModifi
       
       removeView()
       
-      withAnimation(animation) {
+      if let animation {
+        withAnimation(animation) {
+          properties.views.append(.init(id: viewID, view: .init(viewContent(item))))
+        }
+      } else {
         properties.views.append(.init(id: viewID, view: .init(viewContent(item))))
       }
+      
+      properties.window?.makeKeyAndVisible()
     }
   }
   
   private func removeView() {
     if let viewID {
-      withAnimation(animation) {
+      if let animation {
+        withAnimation(animation) {
+          properties.views.removeAll(where: { $0.id == viewID })
+        }
+      } else {
         properties.views.removeAll(where: { $0.id == viewID })
       }
       
@@ -57,7 +67,7 @@ struct OverlayerOptionalModifier<Item: Equatable, ViewContent: View>: ViewModifi
 
 
 struct OverlayerModifier<ViewContent: View>: ViewModifier {
-  var animation: Animation
+  var animation: Animation?
   @Binding var show: Bool
   @ViewBuilder var viewContent: ViewContent
 
@@ -80,15 +90,25 @@ struct OverlayerModifier<ViewContent: View>: ViewModifier {
       viewID = UUID().uuidString
       guard let viewID else { return }
       
-      withAnimation(animation) {
+      if let animation {
+        withAnimation(animation) {
+          properties.views.append(.init(id: viewID, view: .init(viewContent)))
+        }
+      } else {
         properties.views.append(.init(id: viewID, view: .init(viewContent)))
       }
+      
+      properties.window?.makeKeyAndVisible()
     }
   }
   
   private func removeView() {
     if let viewID {
-      withAnimation(animation) {
+      if let animation {
+        withAnimation(animation) {
+          properties.views.removeAll(where: { $0.id == viewID })
+        }
+      } else {
         properties.views.removeAll(where: { $0.id == viewID })
       }
       

--- a/Sources/Overlayer/OverlayerToggleContainer.swift
+++ b/Sources/Overlayer/OverlayerToggleContainer.swift
@@ -10,12 +10,12 @@ import SwiftUI
 
 /// Container view that handles displaying an overlay when an optional item is present
 public struct OverlayerContainer<Content: View, Item: Equatable, OverlayContent: View>: View {
-  var animation: Animation = .default
+  var animation: Animation? = .default
   @Binding var item: Item?
   @ViewBuilder var content: () -> Content
   @ViewBuilder var overlayContent: (Item) -> OverlayContent
   
-  public init(animation: Animation, item: Binding<Item?>, content: @escaping () -> Content, overlayContent: @escaping (Item) -> OverlayContent) {
+  public init(animation: Animation?, item: Binding<Item?>, content: @escaping () -> Content, overlayContent: @escaping (Item) -> OverlayContent) {
     self.animation = animation
     self._item = item
     self.content = content
@@ -48,15 +48,25 @@ public struct OverlayerContainer<Content: View, Item: Equatable, OverlayContent:
       
       removeView()
       
-      withAnimation(animation) {
+      if let animation {
+        withAnimation(animation) {
+          properties.views.append(.init(id: viewID, view: .init(overlayContent(item))))
+        }
+      } else {
         properties.views.append(.init(id: viewID, view: .init(overlayContent(item))))
       }
+        
+      properties.window?.makeKeyAndVisible()
     }
   }
   
   private func removeView() {
     if let viewID {
-      withAnimation(animation) {
+      if let animation {
+        withAnimation(animation) {
+          properties.views.removeAll(where: { $0.id == viewID })
+        }
+      } else {
         properties.views.removeAll(where: { $0.id == viewID })
       }
       
@@ -66,12 +76,12 @@ public struct OverlayerContainer<Content: View, Item: Equatable, OverlayContent:
 }
 
 public struct OverlayerToggleContainer<Content: View, OverlayContent: View>: View {
-  var animation: Animation = .default
+  var animation: Animation? = .default
   @Binding var show: Bool
   @ViewBuilder var content: () -> Content
   @ViewBuilder var overlayContent: () -> OverlayContent
   
-  public init(animation: Animation, show: Binding<Bool>, content: @escaping () -> Content, overlayContent: @escaping () -> OverlayContent) {
+  public init(animation: Animation?, show: Binding<Bool>, content: @escaping () -> Content, overlayContent: @escaping () -> OverlayContent) {
     self.animation = animation
     self._show = show
     self.content = content
@@ -97,7 +107,11 @@ public struct OverlayerToggleContainer<Content: View, OverlayContent: View>: Vie
       viewID = UUID().uuidString
       guard let viewID else { return }
       
-      withAnimation(animation) {
+      if let animation {
+        withAnimation(animation) {
+          properties.views.append(.init(id: viewID, view: .init(overlayContent())))
+        }
+      } else {
         properties.views.append(.init(id: viewID, view: .init(overlayContent())))
       }
     }
@@ -105,7 +119,11 @@ public struct OverlayerToggleContainer<Content: View, OverlayContent: View>: Vie
   
   private func removeView() {
     if let viewID {
-      withAnimation(animation) {
+      if let animation {
+        withAnimation(animation) {
+          properties.views.removeAll(where: { $0.id == viewID })
+        }
+      } else {
         properties.views.removeAll(where: { $0.id == viewID })
       }
       

--- a/Sources/Overlayer/View+Overlayer.swift
+++ b/Sources/Overlayer/View+Overlayer.swift
@@ -11,7 +11,7 @@ import SwiftUI
 public extension View {
   @ViewBuilder
   func overlayer<Item: Equatable, Content: View>(
-    animation: Animation = .snappy,
+    animation: Animation? = .snappy,
     item: Binding<Item?>,
     @ViewBuilder content: @escaping (Item) -> Content
   ) -> some View {
@@ -23,7 +23,7 @@ public extension View {
 public extension View {
   @ViewBuilder
   func overlayer<Content: View>(
-    animation: Animation = .snappy,
+    animation: Animation? = .snappy,
     isPresented: Binding<Bool>,
     @ViewBuilder content: @escaping () -> Content
   ) -> some View {
@@ -36,7 +36,7 @@ extension View {
   /// Convenience function to wrap a view in an OverlayerContainer
   func withOverlayer<Item: Equatable, OverlayContent: View>(
     item: Binding<Item?>,
-    animation: Animation = .default,
+    animation: Animation? = .default,
     @ViewBuilder content: @escaping (Item) -> OverlayContent
   ) -> some View {
     OverlayerContainer(
@@ -50,7 +50,7 @@ extension View {
   /// Convenience function to wrap a view in an OverlayerToggleContainer
   func withOverlayer<OverlayContent: View>(
     isPresented: Binding<Bool>,
-    animation: Animation = .default,
+    animation: Animation? = .default,
     @ViewBuilder content: @escaping () -> OverlayContent
   ) -> some View {
     OverlayerToggleContainer(


### PR DESCRIPTION
# What’s changed

### No-animation mode

Optional Animation argument, when set to nil, performs the view transition instantly—skipping the default system animation.
Useful if you want to orchestrate your own source/destination animations before and after the swap.

### Immediate keyboard focus

After swapping the root view controller, we now call window.makeKeyAndVisible() to ensure the new window becomes key right away.

This guarantees that any text inputs on the destination screen can immediately become first responder and summon the keyboard without delay.

### Why this helps

You get full control over your own animations, without fighting the built-in ones.
The keyboard shows up immediately on the new screen whenever you need user input.

### Example with and without calling makeKeyAndVisible()


https://github.com/user-attachments/assets/bd632d4c-4920-410f-89a5-c6081c90f23b

https://github.com/user-attachments/assets/594d00d3-2ee2-44af-bfac-fd2efdfc8c75


